### PR TITLE
Removes a thrown exception that eats the entire request.

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -18,14 +18,10 @@ async function query({ query, variables, url, token }) {
 		if (e.response.data && e.response.data.errors !== undefined) {
 			throw new Error(e.response.data.errors.map(val => val.message).join(", "));
 		}
-		
+
 		throw e;
 	}
-	
-	if (response.data.errors !== undefined) {
-		throw new Error(response.data.errors.map(val => val.message).join(", "));
-	}
-	
+
 	return response.data.data;
 }
 


### PR DESCRIPTION
Removing this `if` statement allows the users to use normal error handling from their APIs, e.g. providing custom error messages for user feedback in the UI. Currently, if a graphqQL resolver returns an error intentionally, the exception will be thrown and is subsequently returned without the response value.