### PR TITLE
MCE-565 Update sv email

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -20,6 +20,7 @@ async function query({ query, variables, url, token, headers = {} }) {
 			method : "post",
 			headers,
 			maxContentLength: Infinity,
+			maxBodyLength: Infinity,
 			data : {
 				query,
 				variables


### PR DESCRIPTION
Version 0.20.0 of axios introduced a new property of maxBodyLength which is separate to maxContentLength. This defaults to 10mb which means that sv-email tests fail when using this new axios version.
This is a Node only option and defines the max size of the http request content.
https://github.com/axios/axios/pull/2781