### PR TITLE
Axios Update 21.1 => 24

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
 		"mocha": "8.3.1"
 	},
 	"dependencies": {
-		"axios": "0.21.1",
+		"axios": "0.24.0",
 		"jsvalidator": "2.0.0",
 		"lodash": "4.17.21"
 	},


### PR DESCRIPTION
On install, sv-graphql-client is throwing a high security vulnerability because of an outdated version of axios:
![image](https://user-images.githubusercontent.com/18276723/140792323-8b79f03d-9dcc-40d8-a52f-f3ced9c51c2e.png)

- The only breaking change in the Axios changelog that could affect us was reverted, to my first read: [Axios Changelog](https://github.com/axios/axios/blob/master/CHANGELOG.md)
- Tests pass:
- ![image](https://user-images.githubusercontent.com/18276723/140792368-9b313040-e3e2-4104-a9c2-9abe98c91624.png)
- Also added a .gitignore
